### PR TITLE
Fix for downloading individual item from cloud and fix for &timestamp…

### DIFF
--- a/modules/dev_broadlink/broadlink.class.php
+++ b/modules/dev_broadlink/broadlink.class.php
@@ -1963,7 +1963,7 @@ class Cloud extends Broadlink{
 		}
 		
 		$timestamp = round(microtime(true) * 1000);
-		$post = "/rest/1.0/backup?method=list&user=".$this->nickname."&id=".$this->userid."&timestamp=".$timestamp."&token=".$this->get_token($timestamp);
+		$post = "/rest/1.0/backup?method=list&user=".$this->nickname."&id=".$this->userid."&amp;timestamp=".$timestamp."&token=".$this->get_token($timestamp);
 		$host = "ebackup.ibroadlink.com";
 		$headers = array(
 			"GET ".$post." HTTP/1.1",
@@ -1993,7 +1993,7 @@ class Cloud extends Broadlink{
 		
 		$BLbackupFolderName = "SharedData";
 		$timestamp = round(microtime(true) * 1000);
-		$post = "/rest/1.0/backup?method=download&pathname=".$pathname."&timestamp=".$timestamp."&token=".$this->get_token($timestamp);
+		$post = "/rest/1.0/backup?method=download&pathname=".$pathname."&amp;timestamp=".$timestamp."&token=".$this->get_token($timestamp);
 		$host = "ebackup.ibroadlink.com";
 		$timestamp = $timestamp + 56;
 		$headers = array(

--- a/modules/dev_broadlink/dev_broadlink_cloud.inc.php
+++ b/modules/dev_broadlink/dev_broadlink_cloud.inc.php
@@ -58,9 +58,9 @@
 	}
   }  
   if($this->mode=='get_one') {
-	global $id;
+	global $pathname;
 	$cloud = Broadlink::Cloud($this->config['username'], $this->config['userid'], $this->config['loginsession']);
-	$response = $cloud->GetBackup($properties[$id]['PATH']);
+	$response = $cloud->GetBackup($pathname);
 	if($response['error']==0) {
 		$out['OK']='<#LANG_UNPACKED#> '.$response['msg'];
 	} else {

--- a/templates/dev_broadlink/cloud.html
+++ b/templates/dev_broadlink/cloud.html
@@ -51,7 +51,7 @@
    [#SIZE#]
  </td>
  <td>
-   <a href="?view_mode=<#VIEW_MODE#>&mode=get_one&dwl_id=[#ID#]" class="btn btn-default" title="<#LANG_DOWNLOAD#>"><i class="glyphicon glyphicon-cloud-download"></i></a>
+	 <a href="?view_mode=<#VIEW_MODE#>&mode=get_one&pathname=[#PATH#]" class="btn btn-default" title="<#LANG_DOWNLOAD#>"><i class="glyphicon glyphicon-cloud-download"></i></a>
  </td>
 </tr>
 [#end PROPERTIES#]


### PR DESCRIPTION
… in query string

Downloading the backup data from the cloud fails because the query parameter &timestamp gets url encoded as "+tamp". changing the & character with &amp; fixes this issue. 

issue 2 is that downloading individual items from the list does not work. 
the issue was different names in template and php file (dwl_id in html and id in php).
fix ignores passing id and directly passes the pathname to be downloaded.   