### PR TITLE
Доработка синхронизации текущего времени на термостате

### DIFF
--- a/modules/dev_broadlink/broadlink.class.php
+++ b/modules/dev_broadlink/broadlink.class.php
@@ -2045,7 +2045,7 @@ class HYSEN extends Broadlink{
 					$timeDelta = abs( $timeCurrent - $timeTherm);
 
 					// Compensate overflow with 2 minutes confidence
-					if( $timeDelta >= 7*24*60*60 - 120 ) $timeDelta = abs(7*24*60*60 - $timeDelta);
+					if( $timeDelta >= 7*24*60*60 - 60 ) $timeDelta = abs(7*24*60*60 - $timeDelta);
 
 					// Check if thermostat time differs more than 30seconds
 					if ( $timeDelta > 30 ) {

--- a/modules/dev_broadlink/broadlink.class.php
+++ b/modules/dev_broadlink/broadlink.class.php
@@ -2045,7 +2045,7 @@ class HYSEN extends Broadlink{
 					$timeDelta = abs( $timeCurrent - $timeTherm);
 
 					// Compensate overflow with 2 minutes confidence
-					if( $timeDelta >= 7*24*60*60 - 60 ) $timeDelta = abs(7*24*60*60 - $timeDelta);
+					if( $timeDelta >= 7*24*60*60 - 120 ) $timeDelta = abs(7*24*60*60 - $timeDelta);
 
 					// Check if thermostat time differs more than 30seconds
 					if ( $timeDelta > 30 ) {

--- a/modules/dev_broadlink/dev_broadlink.class.php
+++ b/modules/dev_broadlink/dev_broadlink.class.php
@@ -448,64 +448,66 @@ function usual(&$out) {
 			}
 		} elseif ($rec['TYPE']=='hysen') {
                         if($properties[$i]['TITLE']=='remote_lock') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$power=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='power' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_power($value,$power['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='power') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$remote_lock=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='remote_lock' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_power($remote_lock['VALUE'],$value);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='loop_mode') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$auto_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='auto_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$mode_byte = ( $value << 4) + $auto_mode['VALUE'];
 					$rm->set_mode($mode_byte,$sensor['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='auto_mode') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$mode_byte = ( $loop_mode['VALUE'] << 4) + $value;
 					$rm->set_mode($mode_byte,$sensor['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='thermostat_temp') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$rm->set_temp($value);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
 /*                        if($properties[$i]['TITLE']=='hour') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$min=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='min' AND DEVICE_ID='".$rec['ID']."'");
 					$second=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='second' AND DEVICE_ID='".$rec['ID']."'");
 					$dayofweek=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='dayofweek' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_time($value,$min['VALUE'],$second['VALUE'],$dayofweek['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='min') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$hour=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='hour' AND DEVICE_ID='".$rec['ID']."'");
 					$second=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='second' AND DEVICE_ID='".$rec['ID']."'");
 					$dayofweek=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='dayofweek' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_time($hour['VALUE'],$value,$second['VALUE'],$dayofweek['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
 
                         if($properties[$i]['TITLE']=='dayofweek') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$min=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='min' AND DEVICE_ID='".$rec['ID']."'");
 					$second=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='second' AND DEVICE_ID='".$rec['ID']."'");
 					$hour=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='hour' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_time($hour['VALUE'],$min['VALUE'],$second['VALUE'],$value);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
 */                        if($properties[$i]['TITLE']=='sensor') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
 					$dif=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='dif' AND DEVICE_ID='".$rec['ID']."'");
@@ -515,10 +517,10 @@ function usual(&$out) {
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$value,$osv['VALUE'],$dif['VALUE'],$svh['VALUE'],$svl['VALUE'],((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$fre['VALUE'],$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='osv') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$dif=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='dif' AND DEVICE_ID='".$rec['ID']."'");
@@ -528,10 +530,10 @@ function usual(&$out) {
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$value,$dif['VALUE'],$svh['VALUE'],$svl['VALUE'],((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$fre['VALUE'],$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='dif') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
@@ -541,10 +543,10 @@ function usual(&$out) {
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$osv['VALUE'],$value,$svh['VALUE'],$svl['VALUE'],((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$fre['VALUE'],$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='svh') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
@@ -554,10 +556,10 @@ function usual(&$out) {
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$osv['VALUE'],$dif['VALUE'],$value,$svl['VALUE'],((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$fre['VALUE'],$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='svl') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
@@ -567,10 +569,10 @@ function usual(&$out) {
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$osv['VALUE'],$dif['VALUE'],$svh['VALUE'],$value,((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$fre['VALUE'],$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='room_temp_adj') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
@@ -580,10 +582,10 @@ function usual(&$out) {
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$osv['VALUE'],$dif['VALUE'],$svh['VALUE'],$svl['VALUE'],((int)($value*2)>>8 & 0xff),((int)($value*2) & 0xff),$fre['VALUE'],$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='fre') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
@@ -593,10 +595,10 @@ function usual(&$out) {
 					$room_temp_adj=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='room_temp_adj' AND DEVICE_ID='".$rec['ID']."'");
 					$poweron=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='poweron' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$osv['VALUE'],$dif['VALUE'],$svh['VALUE'],$svl['VALUE'],((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$value,$poweron['VALUE']);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='poweron') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$loop_mode=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='loop_mode' AND DEVICE_ID='".$rec['ID']."'");
 					$sensor=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='sensor' AND DEVICE_ID='".$rec['ID']."'");
 					$osv=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='osv' AND DEVICE_ID='".$rec['ID']."'");
@@ -606,13 +608,11 @@ function usual(&$out) {
 					$room_temp_adj=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='room_temp_adj' AND DEVICE_ID='".$rec['ID']."'");
 					$fre=SQLSelectOne("SELECT VALUE FROM dev_broadlink_commands WHERE TITLE='fre' AND DEVICE_ID='".$rec['ID']."'");
 					$rm->set_advanced($loop_mode['VALUE'],$sensor['VALUE'],$osv['VALUE'],$dif['VALUE'],$svh['VALUE'],$svl['VALUE'],((int)($room_temp_adj['VALUE']*2)>>8 & 0xff),((int)($room_temp_adj['VALUE']*2) & 0xff),$fre['VALUE'],$value);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
                         if($properties[$i]['TITLE']=='schedule') {
+					$properties[$i]['VALUE']=$value;
+					SQLUpdate('dev_broadlink_commands', $properties[$i]);
 					$rm->set_schedule($value);
-                                        $properties[$i]['VALUE']=$value;
-                                        SQLUpdate('dev_broadlink_commands', $properties[$i]);
                         }
 		}
     }


### PR DESCRIPTION
В текущей реализации класса HYSEN время на термостате переустанавливается при каждом опросе в течение первой минуты суток (0ч. 0м.). То есть на вновь подключенных термостатах время не будет скорректировано по меньшей мере до до полуночи, причем термостат в это время должен быть доступен а цикл - активен.

Этот PR меняет логику следующим образом: время на термостате проверяется при каждом успешном опросе и если часы убежали больше чем на 30 секунд - они переустанавливаются заново.