### PR TITLE
Добавлена возможность проверки доступности устройств перед опросом

### DIFF
--- a/modules/dev_broadlink/broadlink.class.php
+++ b/modules/dev_broadlink/broadlink.class.php
@@ -671,14 +671,13 @@ class Broadlink{
 		$request   = 'broadlink-monitoring-system';
 
 		switch (self::model($this->devtype)) {
-			case 1:	//SP2
-			case 4:	//MP1
-				$ping_type = 'ICMP';
-				$retries = 1;
-				break;
-			default:
+			case 999: //???
 				$ping_type = 'UDP';
 				$retries = 3;
+				break;
+			default: // 1:SP2, 4:MP1 and other
+				$ping_type = 'ICMP';
+				$retries = 1;
 		}
 
 		if (!$this->host) {

--- a/modules/dev_broadlink/broadlink.class.php
+++ b/modules/dev_broadlink/broadlink.class.php
@@ -2044,7 +2044,7 @@ class HYSEN extends Broadlink{
 					// Delta time, seconds
 					$timeDelta = abs( $timeCurrent - $timeTherm);
 
-					// Compensate overflow with 2 minutes confidence
+					// Compensate overflow with 1 minute confidence
 					if( $timeDelta >= 7*24*60*60 - 60 ) $timeDelta = abs(7*24*60*60 - $timeDelta);
 
 					// Check if thermostat time differs more than 30seconds

--- a/modules/dev_broadlink/dev_broadlink.class.php
+++ b/modules/dev_broadlink/dev_broadlink.class.php
@@ -153,6 +153,7 @@ function admin(&$out) {
  $out['API_TYPE']=$this->config['API'];
  $out['IP_UPDATE']=$this->config['IP_UPDATE'];
  $out['VAL_UPDATE']=$this->config['VAL_UPDATE'];
+ $out['VAL_PING']=$this->config['VAL_PING'];
  $out['DATA_EXPORT_TYPE']=$this->config['DATA_EXPORT_TYPE'];
  if ($this->view_mode=='update_settings') {
    global $api_type;
@@ -163,6 +164,8 @@ function admin(&$out) {
    if($ip_update==true) $this->config['IP_UPDATE']='need'; else $this->config['IP_UPDATE']='not';
    global $val_update;
    if($val_update==true) $this->config['VAL_UPDATE']='on_change'; else $this->config['VAL_UPDATE']='always';
+   global $val_ping;
+   if($val_ping==true) $this->config['VAL_PING']='true'; else $this->config['VAL_PING']='false';
    global $data_export_type;
    $this->config['DATA_EXPORT_TYPE']=$data_export_type;
    $this->saveConfig();

--- a/modules/dev_broadlink/dev_broadlink_check.inc.php
+++ b/modules/dev_broadlink/dev_broadlink_check.inc.php
@@ -78,7 +78,7 @@
 		foreach ($db_rec as $rec) {
 			$response = '';
 			$rm = Broadlink::CreateDevice($rec['IP'], $rec['MAC'], 80, $rec['DEVTYPE']);
-			if(!is_null($rm)) {
+			if( !is_null($rm) && ( ($this->config['VAL_PING']!='true') || $rm->ping()) ) {
 				if(isset($rec['KEYS']) && $rec['KEYS']!='') {
 					$decoded_keys=json_decode($rec['KEYS']);
 					if (time()-$decoded_keys->time > 604800) {

--- a/templates/dev_broadlink/action_admin.html
+++ b/templates/dev_broadlink/action_admin.html
@@ -41,6 +41,12 @@
  </label>
  <div class="controls"><input type="checkbox" name="val_update" [#if VAL_UPDATE="on_change"#] checked[#endif#]></div>
 </div>
+<div class="form-group">
+ <label class="control-label">
+Проверять доступность устройств перед опросом:
+ </label>
+ <div class="controls"><input type="checkbox" name="val_ping" [#if VAL_PING="true"#] checked[#endif#]></div>
+</div>
  <label class="control-label">
 Формат используемый для Импорта/Экспорта:
  </label>


### PR DESCRIPTION
Решение проблемы [отваливания модуля в случае, если часть опрашиваемых устройств недоступны](https://github.com/nick7zmail/MajorDoMo-dev_broadlink/issues/22) (#22)

Что сделано:
1. В настройки модуля добавлен checkbox "Проверять доступность устройств перед опросом".
2. В реализации Broadlink.ping() ICMP режим сделан основным (по умолчанию), а таймаут уменьшен с 500 до 300мс.
3. В цикле опроса устройств при включенной опции "Проверять доступность..." опрос свойств выполняется только если ping не отваливается по таймауту.

_**Note**: Я совсем не разобрался с UDP режимом работы ping(). С моей точки зрения он полностью неработоспособен как минимум под Windows. Но поскольку для его реализации явно была какая-то причина, допускаю что он необходим для каких-то устройств. Но на текущий момент **все** устройства проверяются штатной системной ICMP ping утилитой_

Fixes #22 