### PR TITLE
Fix: Исправлена ошибка count() в PHP 8+ и инициализация переменных

### DIFF
--- a/modules/dev_broadlink/dev_broadlink.class.php
+++ b/modules/dev_broadlink/dev_broadlink.class.php
@@ -363,7 +363,7 @@ function usual(&$out) {
   if ($this->config['API_URL']=='httpbrige') {
    $table='dev_httpbrige_devices';
    $properties=SQLSelect("SELECT * FROM $table WHERE LINKED_OBJECT LIKE '".DBSafe($object)."'");
-   $total=count($properties);
+   $total = is_array($properties) ? count($properties) : 0;
    if ($total) {
     for($i=0;$i<$total;$i++) {
      //to-do
@@ -392,7 +392,7 @@ function usual(&$out) {
   } else {
 	$table='dev_broadlink_commands';
 	$properties=SQLSelect("SELECT * FROM $table WHERE LINKED_OBJECT LIKE '".DBSafe($object)."' AND LINKED_PROPERTY LIKE '".DBSafe($property)."'");
-	$total=count($properties);
+	$total = is_array($properties) ? count($properties) : 0;
 	if ($total) {
     for($i=0;$i<$total;$i++) {
 		$id=$properties[$i]['DEVICE_ID'];
@@ -631,7 +631,8 @@ function usual(&$out) {
  function table_data_set($prop, $dev_id, $val, $sg_val = NULL, $batt = false) {
 	$table='dev_broadlink_commands';
 	$properties=SQLSelectOne("SELECT * FROM $table WHERE TITLE='$prop' AND DEVICE_ID='$dev_id'");
-	$total=count($properties);
+	// Проверка на существование записи (совместимость с PHP 8+)
+	$total = (is_array($properties) && isset($properties['ID'])) ? 1 : 0;
 	if ($total) {
 		if($this->config['VAL_UPDATE']=='on_change' && $val!=$properties['VALUE']) {
 			$need_rec=true;

--- a/scripts/cycle_dev_broadlink.php
+++ b/scripts/cycle_dev_broadlink.php
@@ -21,9 +21,21 @@ $old_second = date('s');
 $old_minute = date('i');
 $old_hour = date('h');
 
+// Инициализация счетчиков
+$s2 = 1;
+$s3 = 1;
+$s5 = 1;
+$s20 = 1;
+$m5 = 1;
+$m10 = 1;
+
 $tmp = SQLSelectOne("SELECT ID FROM dev_httpbrige_devices LIMIT 1");
-if (!$tmp['ID'])
+if (!$tmp['ID']) {
+   // Обновляем статус перед выходом, чтобы показать, что цикл проверялся
+   setGlobal((str_replace('.php', '', basename(__FILE__))) . 'Run', time(), 1);
+   DebMes("Cycle " . basename(__FILE__) . " exited: no devices found in dev_httpbrige_devices", 'boot');
    exit; // no devices added -- no need to run this cycle
+}
 echo date("H:i:s") . " running " . basename(__FILE__) . PHP_EOL;
 $latest_check=0;
 $checkEvery=5; // poll every 5 seconds


### PR DESCRIPTION
Цикл `cycle_dev_broadlink` падал с ошибкой в PHP 8+:
```
count(): Argument #1 ($value) must be of type Countable|array, null given
```

## Исправления
1. **dev_broadlink.class.php** (строка 634):
   - Исправлена проверка перед `count()` для результата `SQLSelectOne()`
   - Добавлена проверка `is_array()` и `isset($properties['ID'])`

2. **dev_broadlink.class.php** (строки 366, 395):
   - Добавлена проверка `is_array()` перед `count()` для `SQLSelect()`

3. **cycle_dev_broadlink.php**:
   - Добавлена инициализация переменных счетчиков (`$s2`, `$s3`, `$s5`, `$s20`, `$m5`, `$m10`)
   - Добавлено обновление статуса перед выходом, если устройств нет

## Тестирование
- Цикл успешно запускается без ошибок
- Статус цикла корректно обновляется
- Совместимо с PHP 8+

## Связанные файлы
- `scripts/cycle_dev_broadlink.php`
- `modules/dev_broadlink/dev_broadlink.class.php`
```